### PR TITLE
add xxHash and optimise FilterTable.checkTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 #Cuckoo Filter For Java#
 This library offers a similar interface to Guava's Bloom filters. In most cases it can be used interchangeably and has additional advantages including thread-safety, concurrent operations, deletions/counting and a configurable hashing algorithm.
 
+This Forked version from MGunlogson/CuckooFilter4J has replaced the MurMur hash functions with xxHash which is much quicker. If you are only using the filter with primitive numbers (long,int,short,byte) you should use the filter from the primitive branch (https://github.com/MPdaedalus/CuckooFilter4J/tree/Primitive-Filter) as it is much quicker due to mightContain() calls creating no Garbage compared to this branch that supports Objects.
+
  * [About Cuckoo Filters](#about-cuckoo-filters)
  * [Installation](#installation)
  * [Usage](#usage)

--- a/src/main/java/com/github/mgunlogson/cuckoofilter4j/FilterTable.java
+++ b/src/main/java/com/github/mgunlogson/cuckoofilter4j/FilterTable.java
@@ -206,9 +206,9 @@ final class FilterTable implements Serializable {
 	 */
 	boolean checkTag(long bucketIndex, int posInBucket, long tag) {
 		long tagStartIdx = getTagOffset(bucketIndex, posInBucket);
-		for (long i = 0; i < bitsPerTag; i++) {
-			boolean tagBitIsSet = (tag & (1L << i)) != 0;
-			if (memBlock.get(i + tagStartIdx) != tagBitIsSet)
+		final int bityPerTag = bitsPerTag;
+		for (long i = 0; i < bityPerTag; i++) {
+			if (memBlock.get(i + tagStartIdx) != ((tag & (1L << i)) != 0))
 				return false;
 		}
 		return true;

--- a/src/main/java/com/github/mgunlogson/cuckoofilter4j/IndexTagCalc.java
+++ b/src/main/java/com/github/mgunlogson/cuckoofilter4j/IndexTagCalc.java
@@ -145,17 +145,18 @@ final class IndexTagCalc<T> implements Serializable {
 		long bucketIndex = 0;
 		HashCode code = hasher.hashObj(item);
 		// 32 bit hash
-		if (hashLength == 32) {
-			int hashVal = code.asInt();
-			bucketIndex = getBucketIndex32(hashVal);
-			// loop until tag isn't equal to empty bucket (0)
-			tag = getTagValue32(hashVal);
-			for (int salt = 1; tag == 0; salt++) {
-				hashVal = hasher.hashObjWithSalt(item, salt).asInt();
-				tag = getTagValue32(hashVal);
-				assert salt < 100;// shouldn't happen in our timeline
-			}
-		} else if (hashLength == 64) {
+//		if (hashLength == 32) {
+//			int hashVal = code.asInt();
+//			bucketIndex = getBucketIndex32(hashVal);
+//			// loop until tag isn't equal to empty bucket (0)
+//			tag = getTagValue32(hashVal);
+//			for (int salt = 1; tag == 0; salt++) {
+//				hashVal = hasher.hashObjWithSalt(item, salt).asInt();
+//				tag = getTagValue32(hashVal);
+//				assert salt < 100;// shouldn't happen in our timeline
+//			}
+//		} else 
+		if (hashLength == 64) {//TODO fix hashLength 32 not 64
 			long hashVal = code.asLong();
 			bucketIndex = getBucketIndex64(hashVal);
 			// loop until tag isn't equal to empty bucket (0)

--- a/src/main/java/com/github/mgunlogson/cuckoofilter4j/Utils.java
+++ b/src/main/java/com/github/mgunlogson/cuckoofilter4j/Utils.java
@@ -55,7 +55,11 @@ public final class Utils {
 		/**
 		 * SipHash(2,4) secure hash.
 		 */
-		sipHash24(3);
+		sipHash24(3),
+		/**
+		 * xxHash 64bit.
+		 */
+		xxHash64(4);
 		private final int id;
 
 		Algorithm(int id) {

--- a/src/main/java/com/google/common/hash/xxHashFunction
+++ b/src/main/java/com/google/common/hash/xxHashFunction
@@ -1,0 +1,197 @@
+package com.google.common.hash;
+
+import java.io.Serializable;
+
+public class xxHashFunction extends AbstractStreamingHashFunction implements Serializable {
+
+	private static final long serialVersionUID = -3736964476904747967L;
+	private final long seed;
+	
+	public xxHashFunction(long newSeed){
+		seed = newSeed;
+	}
+
+	@Override
+	public Hasher newHasher() {
+		return new xxHasher(seed);
+	}
+
+	@Override
+	public int bits() {
+		return 64;
+	}
+	
+	static final class xxHasher extends AbstractByteHasher {
+		
+		private static final long PRIME64_1 = -7046029288634856825L; 
+		private static final long PRIME64_2 = -4417276706812531889L; 
+		private static final long PRIME64_3 = 1609587929392839161L;
+		private static final long PRIME64_4 = -8796714831421723037L; 
+		private static final long PRIME64_5 = 2870177450012600261L;
+		private final long seed;
+		
+		private byte[] ba;
+		private int baIndex=0;
+		
+		xxHasher(long newSeed) {
+			seed = newSeed;
+			ba = new byte[16];
+		}
+
+		@Override
+		public HashCode hash() {
+			return HashCode.fromLong(hash(ba,0,baIndex,seed));
+		}
+
+		@Override
+		protected void update(byte b) {
+			if(baIndex == ba.length) expand();
+			ba[baIndex++] = b;
+		}
+		
+	  @Override
+	  public Hasher putInt(int value) {
+		if(baIndex+3 >=ba.length) expand();
+	    ba[baIndex+3] = (byte)(value >>> 24);
+	    ba[baIndex+2] = (byte)(value >>> 16);
+	    ba[baIndex+1] = (byte)(value >>> 8);
+	    ba[baIndex] =(byte)value;
+	    baIndex+=4;
+	    return this;
+	  }
+
+	  @Override
+	  public Hasher putLong(long value) {
+		if(baIndex+7 >=ba.length) expand();
+	  	ba[baIndex+7] =  (byte)(value >>> 56);
+	  	ba[baIndex+6] =  (byte)(value >>> 48);
+	  	ba[baIndex+5] =  (byte)(value >>> 40);
+	  	ba[baIndex+4] =  (byte)(value >>> 32);
+	  	ba[baIndex+3] =  (byte)(value >>> 24);
+	  	ba[baIndex+2] =  (byte)(value >>> 16);
+	  	ba[baIndex+1] =  (byte)(value >>> 8);
+	  	ba[baIndex] =  (byte)value;
+	  	baIndex+=8;
+	    return this;
+	  }
+	  
+	  private void expand() {
+		  	byte[] newBa = new byte[ba.length*2];
+			for(int i=ba.length-1; i>=0; i--) newBa[i] = ba[i];
+			baIndex = ba.length;
+			ba = newBa;
+	  }
+		
+		private static long readLongLE(byte[] buf, int i) {
+	        return (buf[i] & 0xFFL) | ((buf[i+1] & 0xFFL) << 8) | ((buf[i+2] & 0xFFL) << 16) | ((buf[i+3] & 0xFFL) << 24)
+	                | ((buf[i+4] & 0xFFL) << 32) | ((buf[i+5] & 0xFFL) << 40) | ((buf[i+6] & 0xFFL) << 48) | ((buf[i+7] & 0xFFL) << 56);
+	    }
+		
+		private static int readIntLE(byte[] buf, int i) {
+		        return (buf[i] & 0xFF) | ((buf[i+1] & 0xFF) << 8) | ((buf[i+2] & 0xFF) << 16) | ((buf[i+3] & 0xFF) << 24);
+		}
+	    
+		
+		 /**
+	     * <p>
+	     * Calculates XXHash64 from given {@code byte[]} buffer.
+	     * </p><p>
+	     * This code comes from <a href="https://github.com/jpountz/lz4-java">LZ4-Java</a> created
+	     * by Adrien Grand.
+	     * </p>
+	     *
+	     * @param buf to calculate hash from
+	     * @param off offset to start calculation from
+	     * @param len length of data to calculate hash
+	     * @param seed  hash seed
+	     * @return XXHash.
+	     */
+	    private static long hash(byte[] buf, int off, int len, long seed) {
+	        if (len < 0) {
+	            throw new IllegalArgumentException("lengths must be >= 0");
+	        }
+	        if(off<0 || off>=buf.length || off+len<0 || off+len>buf.length){
+	            throw new IndexOutOfBoundsException();
+	        }
+
+	        final int end = off + len;
+	        long h64;
+
+	        if (len >= 32) {
+	            final int limit = end - 32;
+	            long v1 = seed + PRIME64_1 + PRIME64_2;
+	            long v2 = seed + PRIME64_2;
+	            long v3 = seed + 0;
+	            long v4 = seed - PRIME64_1;
+	            do {
+	                v1 += readLongLE(buf, off) * PRIME64_2;
+	                v1 = Long.rotateLeft(v1, 31);
+	                v1 *= PRIME64_1;
+	                off += 8;
+
+	                v2 += readLongLE(buf, off) * PRIME64_2;
+	                v2 = Long.rotateLeft(v2, 31);
+	                v2 *= PRIME64_1;
+	                off += 8;
+
+	                v3 += readLongLE(buf, off) * PRIME64_2;
+	                v3 = Long.rotateLeft(v3, 31);
+	                v3 *= PRIME64_1;
+	                off += 8;
+
+	                v4 += readLongLE(buf, off) * PRIME64_2;
+	                v4 = Long.rotateLeft(v4, 31);
+	                v4 *= PRIME64_1;
+	                off += 8;
+	            } while (off <= limit);
+
+	            h64 = Long.rotateLeft(v1, 1) + Long.rotateLeft(v2, 7) + Long.rotateLeft(v3, 12) + Long.rotateLeft(v4, 18);
+
+	            v1 *= PRIME64_2; v1 = Long.rotateLeft(v1, 31); v1 *= PRIME64_1; h64 ^= v1;
+	            h64 = h64 * PRIME64_1 + PRIME64_4;
+
+	            v2 *= PRIME64_2; v2 = Long.rotateLeft(v2, 31); v2 *= PRIME64_1; h64 ^= v2;
+	            h64 = h64 * PRIME64_1 + PRIME64_4;
+
+	            v3 *= PRIME64_2; v3 = Long.rotateLeft(v3, 31); v3 *= PRIME64_1; h64 ^= v3;
+	            h64 = h64 * PRIME64_1 + PRIME64_4;
+
+	            v4 *= PRIME64_2; v4 = Long.rotateLeft(v4, 31); v4 *= PRIME64_1; h64 ^= v4;
+	            h64 = h64 * PRIME64_1 + PRIME64_4;
+	        } else {
+	            h64 = seed + PRIME64_5;
+	        }
+
+	        h64 += len;
+
+	        while (off <= end - 8) {
+	            long k1 = readLongLE(buf, off);
+	            k1 *= PRIME64_2; k1 = Long.rotateLeft(k1, 31); k1 *= PRIME64_1; h64 ^= k1;
+	            h64 = Long.rotateLeft(h64, 27) * PRIME64_1 + PRIME64_4;
+	            off += 8;
+	        }
+
+	        if (off <= end - 4) {
+	            h64 ^= (readIntLE(buf, off) & 0xFFFFFFFFL) * PRIME64_1;
+	            h64 = Long.rotateLeft(h64, 23) * PRIME64_2 + PRIME64_3;
+	            off += 4;
+	        }
+
+	        while (off < end) {
+	            h64 ^= (buf[off] & 0xFF) * PRIME64_5;
+	            h64 = Long.rotateLeft(h64, 11) * PRIME64_1;
+	            ++off;
+	        }
+
+	        h64 ^= h64 >>> 33;
+	        h64 *= PRIME64_2;
+	        h64 ^= h64 >>> 29;
+	        h64 *= PRIME64_3;
+	        h64 ^= h64 >>> 32;
+
+	        return h64;
+	    }
+		
+	}
+
+}


### PR DESCRIPTION
The xxHash implementation can only go in the google hash folder as it needs to implement AbstractStreamingHashFunction which is package private.

With FilterTable.checkTag I removed the boolean variable and created a local reference for "bitsPerTag" but did not change loop from increment to deincrement as I don't know what effect it will have on memBlock.get().

In my rather low tech visualVM benchmark the 1/3rd of mightContain() time up used by the murmur hash has completely disappeared, the hash methods don't even show up as measurable time, maybe you could confirm this with your more advanced JMH setup.

The garbage created by mightContain is even worse than i feared as not only is there a overhead from Long objects but also every call creates a new hasher and hashcode object as well ,as well as any arrays and primitives required to do the hashing. I recon each call creates between 50 and 100 bytes of garbage which is a lot for a method that is called millions of times per second.

I will create another branch and strip out the generics and rework the hashing, this will have the added benefit that the xxHash implementation can go in your utils class and the hashing itself will be much simpler as it will only have a single "long" to hash rather than a byte array, it will also create no garbage what so ever and be much faster as well. I will also add methods for smaller primitives which will end up being converted to longs so you only need one class. Should be done by sunday.

Let me know if you have any issues with the pull or your tests reveal errors.